### PR TITLE
chore: use enogu instead of styleText

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -10,6 +10,7 @@
   },
   "nodeModulesDir": "none",
   "imports": {
+    "@ryu/enogu": "jsr:@ryu/enogu@0.6.2",
     "@std/assert": "jsr:@std/assert@1.0.14",
     "@std/cli": "jsr:@std/cli@1.0.22",
     "@std/yaml": "jsr:@std/yaml@1.0.9",

--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,7 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@ryu/enogu@~0.6.2": "0.6.2",
     "jsr:@std/assert@1.0.14": "1.0.14",
     "jsr:@std/cli@1.0.22": "1.0.22",
     "jsr:@std/internal@^1.0.10": "1.0.10",
@@ -11,6 +12,9 @@
     "npm:@types/node@*": "24.2.0"
   },
   "jsr": {
+    "@ryu/enogu@0.6.2": {
+      "integrity": "3209720528773bcc5070c2df90778a9a3d04d11eca6a7f1601a0d38b17ef69f6"
+    },
     "@std/assert@1.0.14": {
       "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4",
       "dependencies": [
@@ -52,6 +56,7 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@ryu/enogu@~0.6.2",
       "jsr:@std/assert@1.0.14",
       "jsr:@std/cli@1.0.22",
       "jsr:@std/jsonc@1.0.2",

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { styleText } from "node:util";
+import { gray, green } from "@ryu/enogu";
 import { parseArgs } from "@std/cli";
 import process from "node:process";
 import { parsePnpmWorkspace, pinPnpmWorkspaceCatalogs } from "./pnpm.ts";
@@ -205,8 +205,8 @@ function pinDependencies(
         pinned[name] = lockedVersion;
         const paddedName = name.padEnd(maxNameLength);
         const paddedVersion = version.padEnd(maxVersionLength);
-        const oldVersion = styleText("gray", paddedVersion);
-        const newVersion = styleText("green", lockedVersion);
+        const oldVersion = gray(paddedVersion);
+        const newVersion = green(lockedVersion);
         console.log(`   ${paddedName}: ${oldVersion} -> ${newVersion}`);
       } else {
         pinned[name] = version;
@@ -483,8 +483,8 @@ function main() {
           const paddedVersion = change.oldVersion.padEnd(
             combinedMaxVersionLength,
           );
-          const oldVersion = styleText("gray", paddedVersion);
-          const newVersion = styleText("green", change.newVersion);
+          const oldVersion = gray(paddedVersion);
+          const newVersion = green(change.newVersion);
           console.log(`   ${paddedName}: ${oldVersion} -> ${newVersion}`);
         }
 


### PR DESCRIPTION
No dependency on Node.js API except for node:fs and node:process