### PR TITLE
fix: unsupport for peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This CLI currently supports `package.json` and `pnpm-workspace.yaml`, but the su
 
 ### Package management files support
 
-- [x] package.json (dependencies, devDependencies, peerDependencies)
+- [x] package.json (dependencies, devDependencies)
 - [x] pnpm-workspace.yaml (catalog, catalogs)
 - [ ] deno.json(c)
 

--- a/src/package-json.ts
+++ b/src/package-json.ts
@@ -3,7 +3,6 @@ import * as v from "@valibot/valibot";
 export interface PackageJson {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
-  peerDependencies?: Record<string, string>;
   workspaces?: string[] | { packages?: string[] };
   [key: string]: unknown;
 }
@@ -13,7 +12,6 @@ const PackageJsonSchema = v.pipe(
   v.looseObject({
     dependencies: v.optional(v.record(v.string(), v.string())),
     devDependencies: v.optional(v.record(v.string(), v.string())),
-    peerDependencies: v.optional(v.record(v.string(), v.string())),
     workspaces: v.optional(
       v.union([
         v.array(v.string()),
@@ -27,7 +25,6 @@ const PackageJsonSchema = v.pipe(
 export const DEPENDENCY_TYPES = [
   "dependencies",
   "devDependencies",
-  "peerDependencies",
 ] as const;
 
 export function parsePackageJson(content: string): PackageJson {

--- a/src/package-json_test.ts
+++ b/src/package-json_test.ts
@@ -10,6 +10,5 @@ Deno.test("parse package.json", () => {
   assertEquals(result.dependencies?.["jsonc-parser"], "^3.3.1");
   assertEquals(result.dependencies?.["@hono/react-compat"], "^0.0.3");
   assertEquals(result.devDependencies?.["enogu"], "~0.6.0");
-  assertEquals(result.peerDependencies?.["react"], ">=18.0.0");
   assertEquals(result.workspaces, ["packages/*", "apps/*"]);
 });


### PR DESCRIPTION
peerDependencies are used for libraries and are therefore excluded from pindeps